### PR TITLE
fix: support Apple silicon

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -64,7 +64,7 @@ get_arch() {
     "arm")
       echo "arm"
     ;;
-    "aarch64")
+    "aarch64" | "arm64")
       echo "arm64"
     ;;
     *)


### PR DESCRIPTION
On macOS, running `uname -m` returns `arm64` instead of `aarch64`, causing the installation of the plugin to fail on newer Apple devices running on M1 silicon. Added that to the condition.

I've tested it successfully by installing the plugin from my fork.