### PR TITLE
fix(version): ec v3.0.0 added suffix v

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -4,93 +4,98 @@ set -e
 set -o pipefail
 
 install_tool() {
-  #local install_type=$1
-  local version=$2
-  local install_path=$3
-  local tmp_download_dir=$4
-  local binary_name=$5
+	#local install_type=$1
+	local version=$2
+	local install_path=$3
+	local tmp_download_dir=$4
+	local binary_name=$5
 
-  local platform
-  local bin_install_path="$install_path/bin"
-  local binary_path="$bin_install_path/${binary_name}"
-  local download_url
-  local download_path
+	local platform
+	local bin_install_path="$install_path/bin"
+	local binary_path="$bin_install_path/${binary_name}"
+	local download_url
+	local download_path
 
-  platform=$(get_platform)
-  download_url=$(get_download_url "$version" "$platform" "$binary_name")
-  download_path="$tmp_download_dir/"$(get_filename "$platform" "$binary_name")
+	platform=$(get_platform)
+	download_url=$(get_download_url "$version" "$platform" "$binary_name")
+	download_path="$tmp_download_dir/"$(get_filename "$platform" "$binary_name")
 
-  echo "Downloading [${binary_name}] from ${download_url} to ${download_path}"
-  curl -Lo "$download_path" "$download_url"
+	echo "Downloading [${binary_name}] from ${download_url} to ${download_path}"
+	curl -Lo "$download_path" "$download_url"
 
-  echo "Creating bin directory"
-  mkdir -p "${bin_install_path}"
+	echo "Creating bin directory"
+	mkdir -p "${bin_install_path}"
 
-  echo "Cleaning previous binaries"
-  rm -f "$binary_path" 2>/dev/null || true
+	echo "Cleaning previous binaries"
+	rm -f "$binary_path" 2>/dev/null || true
 
-  echo "Extracting archive"
-  tar xpf "$download_path" -C "$tmp_download_dir"
+	echo "Extracting archive"
+	tar xpf "$download_path" -C "$tmp_download_dir"
 
-  echo "Copying binary"
-  cp "$(get_binary_path_in_archive "${tmp_download_dir}" "${platform}" "${binary_name}")" "${binary_path}"
-  chmod +x "${binary_path}"
+	echo "Copying binary"
+	cp "$(get_binary_path_in_archive "${tmp_download_dir}" "${platform}" "${binary_name}")" "${binary_path}"
+	chmod +x "${binary_path}"
 }
 
 # ec-linux-amd64.tar.gz
 
 get_binary_path_in_archive() {
-  local archive_dir=$1
-  local platform=$2
-  local binary_name=$3
+	local archive_dir=$1
+	local platform=$2
+	local binary_name=$3
 
-  echo "$archive_dir/bin/$binary_name-$platform"
+	echo "$archive_dir/bin/$binary_name-$platform"
 }
 
 get_platform() {
-  echo "$(uname | tr '[:upper:]' '[:lower:]')-$(get_arch)"
+	echo "$(uname | tr '[:upper:]' '[:lower:]')-$(get_arch)"
 }
 
 get_arch() {
-  local arch
-  arch=$(uname -m)
-  case $arch in
-   "x86_64" | "amd64")
-      echo "amd64"
-    ;;
-    "i386" | "i686")
-      echo "386"
-    ;;
-    "arm")
-      echo "arm"
-    ;;
-    "aarch64" | "arm64")
-      echo "arm64"
-    ;;
-    *)
-      exit 1
-    ;;
-  esac
+	local arch
+	arch=$(uname -m)
+	case $arch in
+	"x86_64" | "amd64")
+		echo "amd64"
+		;;
+	"i386" | "i686")
+		echo "386"
+		;;
+	"arm")
+		echo "arm"
+		;;
+	"aarch64" | "arm64")
+		echo "arm64"
+		;;
+	*)
+		exit 1
+		;;
+	esac
 
 }
 
 get_filename() {
-  local platform="$1"
-  local binary_name="$2"
+	local platform="$1"
+	local binary_name="$2"
 
-  echo "${binary_name}-${platform}.tar.gz"
+	echo "${binary_name}-${platform}.tar.gz"
 }
 
 # https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.2.2/ec-linux-amd64.tar.gz
+# if version is 3.0.0 or higher, use v3.0.0
+# https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.0.0/ec-linux-amd64.tar.gz
 
 get_download_url() {
-  local version="$1"
-  local platform="$2"
-  local binary_name="$3"
-  local filename
-  filename="$(get_filename "$platform" "$binary_name")"
+	local version="$1"
+	local platform="$2"
+	local binary_name="$3"
+	local filename
+	filename="$(get_filename "$platform" "$binary_name")"
 
-  echo "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/${version}/${filename}"
+	if [ "${version%%.*}" -ge 3 ]; then
+		version="v${version}"
+	fi
+	echo "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/${version}/${filename}"
 }
 
 tmp_download_dir="$(mktemp -d -t 'asdf_XXXXXXXX')"

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,18 +4,17 @@ github_coordinates=editorconfig-checker/editorconfig-checker
 releases_path="https://api.github.com/repos/${github_coordinates}/releases"
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
+	cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
 fi
 cmd="$cmd $releases_path"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' \
-    | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
 versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions)
 # shellcheck disable=SC2086
 echo $versions
-


### PR DESCRIPTION
The release of v3.0.0 introduce a breaking change: 

> BREAKING:
> 
> Releases and tags now have a leading v.
> Marked as breaking because this may needs adjustments in the specific wrapper tools for other languages.

cf. https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/v3.0.0

This PR fixes the asdf extension to make it work again