### PR TITLE
fix: remove v from versions in list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -15,6 +15,6 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions)
+versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//;s/^v//' | sort_versions)
 # shellcheck disable=SC2086
 echo $versions


### PR DESCRIPTION
Should fix https://github.com/Gabitchov/asdf-editorconfig-checker/issues/6

With my forked version with a small fix inside :

```
jylenhof@grogu:~$ asdf plugin-add editorconfig-checker https://github.com/jylenhof/asdf-editorconfig-checker
jylenhof@grogu:~$ asdf list all editorconfig-checker
1.1.0
1.1.1
1.1.2
1.1.3
1.2.0
1.2.1
1.3.0
2.0.0
2.0.1
2.0.2
2.0.3
2.0.4
2.1.0
2.2.0
2.3.0
2.3.1
2.3.3
2.3.4
2.3.5
2.4.0
2.5.0
2.6.0
2.7.0
2.7.1
2.7.2
2.8.0
3.0.0
3.0.1
3.0.2
3.0.3
jylenhof@grogu:~$ asdf latest editorconfig-checker
3.0.3
jylenhof@grogu:~$
```